### PR TITLE
排除 Lua 和 TeX 的注释，添加 \LoadClassWithOptions

### DIFF
--- a/file_parser.py
+++ b/file_parser.py
@@ -7,7 +7,7 @@ from typing import TextIO
 LUA_MODULE_PATTERN = re.compile(r'\brequire\s*\(?\s*(?:"|\')(.+?)(?:"|\')')
 LUALIBS_MODULE_PATTERN = re.compile(r'loadmodule\s*\(*\s*(?:"|\')(.+\.lua)(?:"|\')')
 CLASS_PATTERN = re.compile(r'''
-    \\(?:LoadClass|documentclass)\s*
+    \\(?:LoadClass|LoadClassWithOptions|documentclass)\s*
     (?:\[.*\]\s*)?
     \{\s*(.+?)\s*\}
 ''', re.VERBOSE)

--- a/file_parser.py
+++ b/file_parser.py
@@ -4,7 +4,7 @@ import sys
 from typing import TextIO
 
 
-LUA_MODULE_PATTERN = re.compile(r'require\s*\(?\s*(?:"|\')(.+?)(?:"|\')')
+LUA_MODULE_PATTERN = re.compile(r'\brequire\s*\(?\s*(?:"|\')(.+?)(?:"|\')')
 LUALIBS_MODULE_PATTERN = re.compile(r'loadmodule\s*\(*\s*(?:"|\')(.+\.lua)(?:"|\')')
 CLASS_PATTERN = re.compile(r'''
     \\(?:LoadClass|documentclass)\s*
@@ -45,7 +45,9 @@ class Parser:
 
     def _parse_lua(self, fp: TextIO):
         for line in fp:
-            if match := LUA_MODULE_PATTERN.findall(line):
+            if line.lstrip().startswith('--'):
+                continue
+            elif match := LUA_MODULE_PATTERN.findall(line):
                 self.depend.add(match[0] + ".lua")
             elif match := LUALIBS_MODULE_PATTERN.findall(line):
                 self.depend.add(match[0])

--- a/file_parser.py
+++ b/file_parser.py
@@ -54,9 +54,11 @@ class Parser:
 
     def _parse_tex(self, fp: TextIO):
         for line in fp:
-            if line.rstrip() == '\\endinput':
+            if line.lstrip().startswith('%'):
+                continue
+            elif line.rstrip() == '\\endinput':
                 return
-            if not line.startswith('%'):
+            else:
                 self.depend.update(self._parse_tex_line(line))
 
     def _parse_tex_line(self, line: str) -> list[str]:


### PR DESCRIPTION
简单看一下 1b69d09 的结果，感觉有些不对劲。

https://github.com/stone-zeng/tl-depend-analysis/blob/1b69d0981d8755af776cb6d882aee5fa7ebaa4cb/data/tl-depend.json#L25207-L25213

然后发现已经注释掉了。

```
$ grep -r "require" /usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-graphemes.lua:  local p = require'lua-uni-parse'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-graphemes.lua:  local l = lpeg or require'lpeg'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-case.lua:  local p = require'lua-uni-parse'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-case.lua:  local l = lpeg or require'lpeg'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:  local p = require'lua-uni-parse'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:  local require_work
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:      require_work = require_work or qc
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:  if not require_work then
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:-- print(require'inspect'{to_nfd{0x1E0A}, to_nfc{0x1E0A}})
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-normalize.lua:-- print(require'inspect'{to_nfd{0x1100, 0x1100, 0x1161, 0x11A8}, to_nfc{0x1100, 0x1100, 0x1161, 0x11A8}})
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-parse.lua:local lpeg = lpeg or require'lpeg'
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-algos.lua:  case = require'lua-uni-case',
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-algos.lua:  graphemes = require'lua-uni-graphemes',
/usr/local/texlive/2023/texmf-dist/tex/luatex/lua-uni-algos/lua-uni-algos.lua:  normalize = require'lua-uni-normalize',

$ tlmgr info --list luatodonotes

...

run files:
  texmf-dist/tex/lualatex/luatodonotes/inspect.lua
  texmf-dist/tex/lualatex/luatodonotes/luatodonotes.lua
  texmf-dist/tex/lualatex/luatodonotes/luatodonotes.sty
  texmf-dist/tex/lualatex/luatodonotes/path_line.lua
  texmf-dist/tex/lualatex/luatodonotes/path_point.lua
doc files:
  texmf-dist/doc/lualatex/luatodonotes/README.md details="Readme"
  texmf-dist/doc/lualatex/luatodonotes/luatodonotes.pdf details="Package documentation"
```